### PR TITLE
Add missing `winit::window::Window` use statement

### DIFF
--- a/book/MovingToTheGPU.html
+++ b/book/MovingToTheGPU.html
@@ -190,7 +190,7 @@ and handle them as they arrive by looping indefinitely:
         winit::{
             event::{Event, WindowEvent},
             event_loop::{ControlFlow, EventLoop},
-            window::WindowBuilder,
+            window::{Window, WindowBuilder},
         },
     };
 


### PR DESCRIPTION
This was included correctly in the code template but was missing from the book listing (found by @trevordblack in #10)